### PR TITLE
Add removal of profile photos on reset

### DIFF
--- a/js/display.js
+++ b/js/display.js
@@ -215,22 +215,46 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     confirmReset.addEventListener('click', async function() {
-    try {
-        // Verwijder alle deelnemers uit Supabase (pas 'id' aan naar jouw echte kolomnaam)
-        let { error } = await window.supabaseClient
-            .from('participants')
-            .delete()
-            .neq('id', 0);
+        try {
+            // Haal alle deelnemers op om de bestandsnamen van de foto's te weten
+            const { data: participants, error: fetchError } = await window.supabaseClient
+                .from('participants')
+                .select('photo_url');
 
-        if (error) throw error;
+            if (fetchError) throw fetchError;
 
-        displayContainer.innerHTML = '';
-        document.getElementById('participant-count').textContent = 'Aantal ingecheckt: 0';
-        resetModal.style.display = 'none';
-        alert('Alle deelnemers zijn verwijderd uit Supabase én het display.');
-    } catch (error) {
-        alert("Fout bij resetten deelnemers: " + error.message);
-    }
-});
+            // Bepaal de paden van de foto's binnen de bucket
+            const photoPaths = (participants || [])
+                .map(p => {
+                    const match = p.photo_url && p.photo_url.match(/profile-photos\/(.+)$/);
+                    return match ? match[1] : null;
+                })
+                .filter(Boolean);
+
+            if (photoPaths.length) {
+                const { error: storageError } = await window.supabaseClient
+                    .storage
+                    .from('profile-photos')
+                    .remove(photoPaths);
+
+                if (storageError) throw storageError;
+            }
+
+            // Verwijder alle deelnemers uit Supabase
+            const { error } = await window.supabaseClient
+                .from('participants')
+                .delete()
+                .neq('id', 0);
+
+            if (error) throw error;
+
+            displayContainer.innerHTML = '';
+            document.getElementById('participant-count').textContent = 'Aantal ingecheckt: 0';
+            resetModal.style.display = 'none';
+            alert('Alle deelnemers en profielfoto\'s zijn verwijderd.');
+        } catch (error) {
+            alert("Fout bij resetten deelnemers: " + error.message);
+        }
+    });
 
 });


### PR DESCRIPTION
## Summary
- ensure Reset button also removes uploaded profile pictures from Supabase storage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851729a3e84832684d1e26edfeaa0aa